### PR TITLE
fix: remove duplicate backend name in config.yml

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -1,10 +1,7 @@
 backend:
-  # Use netlify identity as backend
-  name: git-gateway
-  branch: master
-  ### enable below lines for github integration ###
   name: github
   repo: jacquesfu/odevs-eleventy-starter
+  branch: master
   open_authoring: true
 media_folder: "src/static/img"
 public_folder: "/static/img"


### PR DESCRIPTION
There was a duplicate backend name in the Netlify CMS config.yml that was preventing the Netlify CMS admin to load for [open authoring](https://www.netlifycms.org/docs/open-authoring/).