### PR TITLE
Removed Attribution section on Code of Conduct that contained broken links

### DIFF
--- a/src/code-of-conduct/index.html
+++ b/src/code-of-conduct/index.html
@@ -92,10 +92,6 @@ Harassment includes, but is not limited to:
     </li>
 <ul>
 </div>
-After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.</div><div>
-<h2>Attribution & Acknowledgements</h2>
-
-The Orlando Devs Community has joined other community leaders (such as <a class="body-link" href="https://www.djangoproject.com/conduct/reporting"/>Django</a>, <a class="body-link" href="https://www.python.org/community/diversity/">Python</a>, <a class="body-link" href="https://www.ubuntu.com/about/about-ubuntu/conduct">Ubuntu</a>, <a class="body-link" href="http://todogroup.org/opencodeofconduct/#attribution--acknowledgements">etc</a>) in implementing a slightly modified version of the <a class="body-link" href="http://todogroup.org/opencodeofconduct/">Open Code of Conduct Project </a> created by the <a class="body-link" href="http://todogroup.org">TODO Group</a>. We cannot thank enough everyone who has helped this Code of Conduct become a reality.
-
+After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.
 </div>
 </div>


### PR DESCRIPTION
Removed Attribution section on Code of Conduct that contained broken links