### PR TITLE
board updates 08-17

### DIFF
--- a/src/_data/board.yaml
+++ b/src/_data/board.yaml
@@ -8,7 +8,7 @@ directors:
     position:  VP of Product and Programs at DataKind
   - name: Jacques Fu
     role: Treasurer
-    position: Co-Founder of Staxx and Beam.gg, Author of "Time Hacks"
+    position: Co-Founder of Staxx and Senseily, Author of "Time Hacks"
     
 advisors:
   - name: Andrew Kozlik


### PR DESCRIPTION
- updates "Beam.gg" to "Senseily" in Jacques Fu position value