### PR TITLE
Edit title copy on the home page

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story-template.md
+++ b/.github/ISSUE_TEMPLATE/user-story-template.md
@@ -1,0 +1,23 @@
+---
+name: User Story template
+about: General User Story Template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Story Title Here
+
+## User Story
+
+As a co-organizer of Orlando DevOps group, I would like to DO SOMETHING so that WE HAVE AN OUTCOME
+
+## Tasks
+
+- [ ] Task 1
+- [ ] Task 2
+
+## Extra Notes
+
+> NOTE: Whatever else should be known to help complete this story / tasks.

--- a/.github/ISSUE_TEMPLATE/user-story-template.md
+++ b/.github/ISSUE_TEMPLATE/user-story-template.md
@@ -11,7 +11,7 @@ assignees: ''
 
 ## User Story
 
-As a co-organizer of Orlando DevOps group, I would like to DO SOMETHING so that WE HAVE AN OUTCOME
+As a member of Orlando DevOps group, I would like to DO SOMETHING so that WE HAVE AN OUTCOME / Business Value
 
 ## Tasks
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@ path: home
     </strong>
   </h1>
 
-    <p class="flex md:py-4 font-Poppins">This is a community built of developers in Orlando and the Central Florida Area</p>
+    <p class="flex md:py-4 font-Poppins">Embark on a journey within a close-knit community sculpted by the talent of Orlando and Central Florida's developers.</p>
 
   {% include "./_includes/partials/content.html" %}
 </div>


### PR DESCRIPTION
Small change to the copy on the home page

<img width="1582" alt="image" src="https://github.com/jacquesfu/odevs-eleventy-starter/assets/2068912/ea89ad5b-c74c-4b01-8a1a-960e9c29d7ea">

This PR is a WIP. I don't love this change. It's more to start a conversation around what an alternative heading might look like. I thought the existing copy sounds a bit awkward